### PR TITLE
Expose Zone and Era

### DIFF
--- a/src/Time.elm
+++ b/src/Time.elm
@@ -4,7 +4,8 @@ effect module Time where { subscription = MySub } exposing
   , every
   , posixToMillis
   , millisToPosix
-  , Zone
+  , Zone(..)
+  , Era
   , utc
   , here
   , toYear


### PR DESCRIPTION
As exposed in the issue, without access to the Zone constructor is not possible pattern match on the `Zone` and extract it's information. It blocks the development for external packages.

resolves #8 