### PR TITLE
Remove information about example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ toUtcString time =
 
 Notice that we provide the `utc` time zone to `toHour` and `toMinute`!
 
-Go [here](https://elm-lang.org/examples/time) for a little example application that uses time. It can help you get everything hooked up in practice!
-
 
 ## Recurring Events
 


### PR DESCRIPTION
As there is no examples now on elm-lang.org page. This like is obsolete.