### PR TITLE
fix kernel call to Elm.Kernel.Scheduler.rawSpawn

### DIFF
--- a/src/Elm/Kernel/Time.js
+++ b/src/Elm/Kernel/Time.js
@@ -2,7 +2,7 @@
 
 import Time exposing (customZone, Name, Offset)
 import Elm.Kernel.List exposing (Nil)
-import Elm.Kernel.Scheduler exposing (binding, succeed)
+import Elm.Kernel.Scheduler exposing (binding, succeed, rawSpawn)
 
 */
 
@@ -19,7 +19,7 @@ var _Time_setInterval = F2(function(interval, task)
 {
 	return __Scheduler_binding(function(callback)
 	{
-		var id = setInterval(function() { _Scheduler_rawSpawn(task); }, interval);
+		var id = setInterval(function() { __Scheduler_rawSpawn(task); }, interval);
 		return function() { clearInterval(id); };
 	});
 });


### PR DESCRIPTION
It is my understanding that references to kernel functions in other files should begin with a double underscore and they should be imported at the top of the file. Otherwise, the deadcode eliminator may remove the needed file.