### PR TITLE
Clarify docs for toSecond.

### DIFF
--- a/src/Time.elm
+++ b/src/Time.elm
@@ -285,13 +285,15 @@ toMinute zone time =
   modBy 60 (toAdjustedMinutes zone time)
 
 
-{-| What second is it?
+{-| What second is it? (From 0 to 59)
 
     import Time exposing (toSecond, utc, millisToPosix)
 
-    toSecond utc (millisToPosix    0) == 0
-    toSecond utc (millisToPosix 1234) == 1
-    toSecond utc (millisToPosix 5678) == 5
+    toSecond utc (millisToPosix     0) == 0
+    toSecond utc (millisToPosix  1234) == 1
+    toSecond utc (millisToPosix  5678) == 5
+    toSecond utc (millisToPosix 74123) == 14
+
 -}
 toSecond : Zone -> Posix -> Int
 toSecond _ time =


### PR DESCRIPTION
I wasn't 100% sure based on the existing docs whether this was
intended to be analagous to toHour, toMinute, etc, or if it just
converted to posix time in seconds. In hindsight, the latter wouldn't
have made much sense, but I was thrown by the facts that:

1. All of the other functions which return a value in a range like this
   say "From 0 to ..", but this one doesn't.
2. The examples don't disambiguate this.

So this patch makes minor improvements to the docs, including the range
for consistency and adding another example that disambiguates.