### PR TITLE
Get the month as an int

### DIFF
--- a/src/Time.elm
+++ b/src/Time.elm
@@ -204,9 +204,12 @@ toYear zone time =
 
     -- pretend `nyc` is the `Zone` for America/New_York.
 -}
+toMonthInt : Zone -> Posix -> Int
+toMonthInt zone time = (toCivil (toAdjustedMinutes zone time)).month
+
 toMonth : Zone -> Posix -> Month
 toMonth zone time =
-  case (toCivil (toAdjustedMinutes zone time)).month of
+  case toMonthInt zone time of
     1  -> Jan
     2  -> Feb
     3  -> Mar


### PR DESCRIPTION
It is annoying to have to convert back yourself if you don't want the enum variant (which I assume is not uncommon).